### PR TITLE
Add README and requirements for slides generation.

### DIFF
--- a/slides/README.md
+++ b/slides/README.md
@@ -1,0 +1,6 @@
+To install packages needed to generate the slides:
+```
+pip install requirements.txt
+```
+
+Note: for some reason if you install only `htmlark` and not `html[parsers]`, you'll get a blank HTML page.

--- a/slides/README.md
+++ b/slides/README.md
@@ -3,4 +3,4 @@ To install packages needed to generate the slides:
 pip install requirements.txt
 ```
 
-Note: for some reason if you install only `htmlark` and not `html[parsers]`, you'll get a blank HTML page.
+Note: for some reason if you `pip install` `htmlark` and not `html[parsers]`, you'll get a blank HTML page.

--- a/slides/requirements.txt
+++ b/slides/requirements.txt
@@ -1,0 +1,2 @@
+remarker
+htmlark[parsers]


### PR DESCRIPTION
If you naively do `pip install remarker htmlark` the `slides.html` is blank:
```
<!DOCTYPE html>

<html>
<head>
<title>Presentation</title>
<meta charset="utf-8"/>
<style></style></head></html><!--Generated by HTMLArk 2019-11-08 11:40:12.562830. Original URL None-->
```

For some reasons you need to do `pip install htmlark[parsers]`. I added a README and requirements.txt.