### PR TITLE
Add index for slides rendering in Github Pages

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Presentation</title>
+  <meta charset="utf-8">
+  <link rel="stylesheet" type="text/css" href="custom.css">
+</head>
+<body>
+<textarea id="source"></textarea>
+<script src="https://remarkjs.com/downloads/remark-latest.min.js">
+</script>
+<script>
+  var slideshow = remark.create({
+    sourceUrl: getUrlParameter('file') ? getUrlParameter('file') : 'slides.md'
+  });
+
+  function getUrlParameter(name) {
+    name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
+    var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+    var results = regex.exec(location.search);
+    return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+  };
+</script>
+</body>
+</html>


### PR DESCRIPTION
I added `index.html` to preview slides using Github pages with an url parameter to choose which markdown file to load.

Example : https://benoit.rospars.me/scikit-learn-tutorial/slides/?file=slides.md

I don't think CI is needed for now.