### PR TITLE
Add github actions to export html and pdf in dist

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+        architecture: 'x64'
+
+    - name: Install python dependencies
+      working-directory: ./slides
+      run: pip install -r requirements.txt
+
+    - name: Install npm dependencies
+      run: npm install -g bellbind/remarkjs-pdf
+
+    - name: Export html
+      working-directory: ./slides
+      run: make && mkdir ../dist && mv *.html ../dist/
+    - name: Export pdf
+      working-directory: ./dist
+      run: for f in *.html ; do remarkjs-pdf "$f"; done
+
+    - name: Upload distributed files
+      uses: actions/upload-artifact@v1
+      with:
+        name: dist
+        path: dist/


### PR DESCRIPTION
Hello,

I added a github actions file to export slides to html and pdfs. Exported files are then downloadable as artifacts (top right of the build page, see below).

![image](https://user-images.githubusercontent.com/5736114/69326705-8b292a00-0c4c-11ea-9f32-8761f92e4859.png)


